### PR TITLE
Fix error that leads to game over if there is a tetromino in that position when the block line is inserted

### DIFF
--- a/source/board/board.cpp
+++ b/source/board/board.cpp
@@ -310,14 +310,18 @@ bool Board::insert_line(int ins_row)
         game_board[r] = ~(1 << ((rand_gen.get_rand_int() % 10) + 3));
     }
 
-    while (!can_place_mino(new_r, curr_c, curr_rot) && index < ins_row)
+    while (!can_place_mino(new_r, curr_c, curr_rot) && new_r > 0)
     {
         new_r--;
         index++;
     }
 
     if(index == 0) return true;
-    else if(index >= ins_row) return false;
+    else if(new_r < 2)
+    {
+        active_mino.set_pos(new_r, curr_c);
+        return false;
+    }
     else
     {
         active_mino.set_pos(new_r, curr_c);


### PR DESCRIPTION
# 요약
<!-- PR 요약을 간단히 작성 -->

## 변경 사항
<!--변경사항 간단히 작성 -->
- 블록 라인이 삽입될 때 그 위치에 테트로미노가 있으면 게임 오버가 일어나는 문제 수정
- 삽입된 블록 라인들 위로 테트로미노가 올라가도록 변경

## 관련 이슈
<!--해당 PR과 연관된 이슈가 있다면 작성, 없으면 삭제 -->
- Closes #25 

## 체크리스트
<!--괄호 안에 x표시-->
- [x] 코드 스타일 준수
- [x] 빌드/테스트 통과
