### PR TITLE
[Refactor] Migrate user input processing from Board to RuleEngine

### DIFF
--- a/include/board/board.hpp
+++ b/include/board/board.hpp
@@ -14,22 +14,35 @@ class Board
     mino game_board[22];
     bool is_mino_active;
 
-    void update_board();
     void draw_board();
     void draw_mino();
     void draw_saved_mino();
-    bool can_place_mino(int new_r, int new_c, int new_rot);
 
     public:
     Board();
+
+    std::pair<int, int> get_active_mino_pos();
+    int get_active_mino_rotation();
+    
+    void set_active_mino_pos(int new_r, int new_c);
+    void set_active_mino_rotation(int new_rot);
+
     bool has_active_mino();
-    void move_mino(int cmd);
+    bool has_swaped_mino();
+
+    bool can_place_mino(int new_r, int new_c, int new_rot);
+    void update_board();
+
     bool spawn_mino(int type);
     void swap_mino();
+
     bool is_line_full(int row);
+
     const uint16_t* get_board() const;
+
     void delete_line(int del_row);
     bool insert_line(int ins_row);
+
     void render(); // 추후 UI 전용 객체로 이전
 };
 

--- a/include/game_rule/game_rule.hpp
+++ b/include/game_rule/game_rule.hpp
@@ -9,9 +9,12 @@ class RuleEngine
     int time_for_level_up[11];
     int level_game_time;
     int current_level;
+    bool enable_kick;
+    Board& board;
 
     public:
-    RuleEngine();
+    RuleEngine(Board& board);
+    void process(int user_input);
     bool is_game_over(const uint16_t* board);
     int update_score(Board& board);
     bool time_and_level_update();

--- a/source/board/board.cpp
+++ b/source/board/board.cpp
@@ -31,6 +31,15 @@ bool Board::has_active_mino()
 }
 
 /**
+ * @brief swap된 mino가 있는지 반환
+ * @return swap된 mino가 있으면 true 반환
+ */
+bool Board::has_swaped_mino()
+{
+    return is_mino_swaped;
+}
+
+/**
  * @brief 테트로미노가 새로운 위치와 회전 상태일 때 보드 상에서 충돌이 있는 지 판정
  * @return false: 충돌 / true: 충돌 없음
  */
@@ -54,76 +63,6 @@ bool Board::can_place_mino(int new_r, int new_c, int new_rot)
     }
 
     return true;
-}
-
-/**
- * @brief 테트로미노 이동. 회전 및 좌우 이동 시에 막히는 경우 명령 무시, 아래 이동 시에 막히는 경우 보드에 고정, 막히지 않는 경우 테트로미노 위치 이동
- */
-void Board::move_mino(int cmd)
-{   
-    if (!is_mino_active) return;
-
-    auto [curr_r, curr_c] = active_mino.get_pos();
-    int curr_rot = active_mino.get_rotation();
-    int new_r, new_c, new_rot;
-    int move_result;
-
-    if (curr_rot == 4) curr_rot = 0;
-    else if (curr_rot == -1) curr_rot = 3;  
-
-    if (cmd == Action::SWAP)
-    {
-        if (is_mino_swaped == false)
-            swap_mino();
-        else return;
-    }
-
-    if (cmd == Action::LEFT || cmd == Action::RIGHT)
-    {
-        new_r = curr_r;
-        new_c = cmd == Action::LEFT ? curr_c - 1 : curr_c + 1;
-        new_rot = curr_rot;
-
-        if (can_place_mino(new_r, new_c, new_rot))
-        {
-            active_mino.set_pos(new_r, new_c);
-        }
-        else return;
-    }
-
-    if (cmd == Action::DROP)
-    {
-        new_r = curr_r + 1;
-        new_c = curr_c;
-        new_rot = curr_rot;
-
-        if (can_place_mino(new_r, new_c, new_rot))
-        {
-            active_mino.set_pos(new_r, new_c);
-        }
-        else
-        {
-            update_board();
-            is_mino_active = false;
-        }
-    }
-
-    if (cmd == Action::ROTATE_CCW || cmd == Action::ROTATE_CW)
-    {
-        new_r = curr_r;
-        new_c = curr_c;
-        new_rot = cmd == Action::ROTATE_CW ? curr_rot + 1 : curr_rot - 1;
-
-        if (new_rot == -1) new_rot = 3;
-        else if (new_rot == 4) new_rot = 0;
-
-        if (can_place_mino(new_r, new_c, new_rot))
-        {
-            active_mino.set_pos(new_r, new_c);
-            active_mino.set_rotation(new_rot);
-        }
-        else return;
-    }
 }
 
 /**
@@ -160,6 +99,8 @@ void Board::update_board()
         mino_row <<= (9 - pos_c);
         game_board[pos_r] |= mino_row;
     }
+
+    is_mino_active = false;
 }
 
 /**

--- a/source/engine/Engine.cpp
+++ b/source/engine/Engine.cpp
@@ -18,7 +18,7 @@ void Engine::run()
 {
     Board board;
     Input input;
-    RuleEngine rule;
+    RuleEngine rule(board);
     TetrominoQueue& tetromino_queue = TetrominoQueue::get_instance();
 
     int curr_mino = 0;
@@ -45,7 +45,7 @@ void Engine::run()
         if (diff >= chrono::milliseconds(500))
         {
             base_time = chrono::steady_clock::now();
-            board.move_mino(Action::DROP);
+            rule.process(Action::DROP);
             board.render();
             is_level_up = rule.time_and_level_update();
         }
@@ -54,8 +54,7 @@ void Engine::run()
 
         if (action != -1) 
         {
-            if (action == Action::HARD_DROP) while (board.has_active_mino()) board.move_mino(Action::DROP);
-            else board.move_mino(action);
+            rule.process(action);
             tetromino_queue.draw_tetromino_queue();
             board.render();
         }

--- a/source/game_rule/game_rule.cpp
+++ b/source/game_rule/game_rule.cpp
@@ -1,6 +1,7 @@
 #include "game_rule/game_rule.hpp"
+#include "input/action.hpp"
 
-RuleEngine::RuleEngine() : level_game_time(0), current_level(1)
+RuleEngine::RuleEngine(Board& board) : level_game_time(0), current_level(1), board(board), enable_kick(true)
 {
     // 120 == 1 minute, when timer is 500ms
     time_for_level_up[0] = 0;
@@ -14,6 +15,68 @@ RuleEngine::RuleEngine() : level_game_time(0), current_level(1)
     time_for_level_up[8] = 120;
     time_for_level_up[9] = 120;
     time_for_level_up[10] = 120;
+}
+
+/**
+ * @brief 유저 인풋을 처리하여 board에 지시
+ * @param user_input
+ */
+void RuleEngine::process(int user_input)
+{
+    auto [curr_r, curr_c] = board.get_active_mino_pos();
+    int curr_rot = board.get_active_mino_rotation();
+    int new_r, new_c, new_rot;
+
+    if (user_input == Action::DROP)
+    {
+        new_r = curr_r + 1;
+        new_c = curr_c;
+        new_rot = curr_rot;
+
+        if (board.can_place_mino(new_r, new_c, new_rot)) board.set_active_mino_pos(new_r, new_c);
+        else board.update_board();
+    }
+    else if (user_input == Action::LEFT || user_input == Action::RIGHT)
+    {
+        new_r = curr_r;
+        new_c = (user_input == Action::LEFT ? curr_c - 1 : curr_c + 1);
+        new_rot = curr_rot;
+        
+        if (board.can_place_mino(new_r, new_c, new_rot)) board.set_active_mino_pos(new_r, new_c);
+    }
+    else if (user_input == Action::ROTATE_CCW || user_input == Action::ROTATE_CW)
+    {
+        new_r = curr_r;
+        new_c = curr_c;
+        new_rot = (user_input == Action::ROTATE_CW ? curr_rot + 1 : curr_rot - 1);
+
+        if (new_rot == -1) new_rot = 3;
+        else if (new_rot == 4) new_rot = 0;
+
+        if (board.can_place_mino(new_r, new_c, new_rot))
+        {
+            board.set_active_mino_pos(new_r, new_c);
+            board.set_active_mino_rotation(new_rot);
+        }
+    }
+    else if (user_input == Action::HARD_DROP)
+    {
+        while (board.has_active_mino())
+        {
+            new_r = curr_r + 1;
+            new_c = curr_c;
+            new_rot = curr_rot;
+
+            if (board.can_place_mino(new_r, new_c, new_rot)) board.set_active_mino_pos(new_r, new_c);
+            else board.update_board();
+        }
+    }
+    else if (user_input == Action::SWAP)
+    {
+        if (board.has_swaped_mino() == false)
+            board.swap_mino();
+        else return;
+    }
 }
 
 int RuleEngine::update_score(Board& board)


### PR DESCRIPTION
# 요약
- Migrate user input processing logic from Board to RuleEngine

## 변경 사항
- Migrated input processing logic from `Board::move_mino(int cmd)` to `RuleEngine::process(int user_input)`.
- Removed `Board::move_mino(int cmd)`.
- Added some getters and setters in `Board`.
- Modified `Engine` according to changes as described above.

## 관련 이슈
- Closes #22 

## 체크리스트
- [x] 코드 스타일 준수
- [x] 빌드/테스트 통과
- [x] 문서/주석 업데이트
