### PR TITLE
Remove singleton pattern from timer class

### DIFF
--- a/core/include/util/timer.hpp
+++ b/core/include/util/timer.hpp
@@ -9,12 +9,9 @@ class Timer
     std::chrono::steady_clock::time_point base_time;
     std::chrono::steady_clock::time_point base_500ms_time;
     std::chrono::steady_clock::time_point curr_time;
-    Timer();
 
   public:
-    static Timer& get_instance();
-    Timer(const Timer&) = delete;
-    Timer& operator=(const Timer&) = delete;
+    Timer();
     void set_curr_time();
     bool check_500ms_time();
     int get_seconds();

--- a/core/source/engine/multi_engine.cpp
+++ b/core/source/engine/multi_engine.cpp
@@ -25,7 +25,7 @@ void MultiEngine::run(bool is_server)
     unique_ptr<GameRule> rule = create_rule("VERSUS", board);
     KeyMapper key_mapper;
     TetrominoQueue& tetromino_queue = TetrominoQueue::get_instance();
-    Timer& timer = Timer::get_instance();
+    Timer timer;
     std::vector<std::pair<std::string, std::string>> ids_ips = lobby->get_client_ids_ips();
     std::unordered_map<std::string, std::string> active_user = lobby->get_ids(is_server);
     PacketStruct recv_pkt;

--- a/core/source/engine/solo_engine.cpp
+++ b/core/source/engine/solo_engine.cpp
@@ -24,7 +24,7 @@ void SoloEngine::run(bool is_server)
     Board board;
     unique_ptr<GameRule> rule = create_rule("ZEN", board);
     TetrominoQueue& tetromino_queue = TetrominoQueue::get_instance();
-    Timer& timer = Timer::get_instance();
+    Timer timer;
     KeyMapper key_mapper;
 
     int curr_mino = 0;

--- a/core/source/util/timer.cpp
+++ b/core/source/util/timer.cpp
@@ -9,12 +9,6 @@ Timer::Timer()
     curr_time = base_500ms_time;
 }
 
-Timer& Timer::get_instance()
-{
-    static Timer instance;
-    return instance;
-}
-
 void Timer::set_curr_time() { curr_time = std::chrono::steady_clock::now(); }
 
 bool Timer::check_500ms_time()

--- a/test/core/util/util_test.cpp
+++ b/test/core/util/util_test.cpp
@@ -7,7 +7,7 @@
 
 TEST(TimerTest, all)
 {
-    Timer& t = Timer::get_instance();
+    Timer t;
     t.set_curr_time();
     std::this_thread::sleep_for(std::chrono::milliseconds(500));
     t.set_curr_time();


### PR DESCRIPTION
# 요약
<!-- PR 요약을 간단히 작성 -->
테스트 및 타이머 초기화 관련 문제 해소를 위한
타이머 클래스에 적용되었던 싱글톤 패턴 제거

## 변경 사항
<!--변경사항 간단히 작성 -->
- 타이머 클래스에 적용되었던 싱글톤 패턴 제거

## 체크리스트
<!--괄호 안에 x표시-->
- [x] 코드 스타일 준수
- [x] 빌드/테스트 통과
- [ ] 문서/주석 업데이트
