### PR TITLE
[Fix] fix broadcast ip address not found in windows

### DIFF
--- a/platform/window/source/lobby_network/window_lobby_network.cpp
+++ b/platform/window/source/lobby_network/window_lobby_network.cpp
@@ -61,11 +61,11 @@ void WindowLobbyNetwork::find_broadcast_ip(char* broadcast_ip)
     if (GetAdaptersAddresses(AF_INET, 0, nullptr, adapters, &size) != NO_ERROR) return;
 
     for (auto a = adapters; a; a = a->Next) {
+        if (a->Ipv4Enabled == 0) continue;
+
+        if (a->Dhcpv4Enabled == 0) continue;
+
         if (a->OperStatus != IfOperStatusUp) continue;
-
-        if (a->IfType == IF_TYPE_SOFTWARE_LOOPBACK) continue;
-
-        if (a->PhysicalAddressLength == 0) continue;
 
         for (auto u = a->FirstUnicastAddress; u; u = u->Next) {
             SOCKADDR_IN* sa = (SOCKADDR_IN*) u->Address.lpSockaddr;


### PR DESCRIPTION
# 요약
<!-- PR 요약을 간단히 작성 -->
윈도우에서 현재 네트워크에 연결된 IP주소를 파악하지 못해 정상적인 브로드캐스트 주소를 생성할 수 없는 문제 해결

## 변경 사항
<!--변경사항 간단히 작성 -->
- 윈도우에서 현재 네트워크에 연결된 IP주소를 파악할 수 있도록 로직 변경

## 체크리스트
<!--괄호 안에 x표시-->
- [x] 코드 스타일 준수
- [x] 빌드/테스트 통과
- [ ] 문서/주석 업데이트
